### PR TITLE
Allowing Specifying Quiz Templates in Shortcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Added
+- Shortcode received optional attributes `quiz_template` and `result_template`,
+whilch allow overriding the default template.
+- Plugin templates can now be overridden from the theme, including child theme.
+
+### Changed
+- Changed some config keys.
 
 ## [0.1.0-alpha2] - 2019-03-26
 ### Changed

--- a/classes/class-file-path-resolver.php
+++ b/classes/class-file-path-resolver.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace XedinUnknown\SQuiz;
+
+use Throwable;
+
+/**
+ * Resolves a relative path to an absolute one.
+ *
+ * This implementation will check a number of base paths for the relative path,
+ * and return the absolute path of the first match.
+ *
+ * @package SQuiz
+ */
+class File_Path_Resolver {
+
+    protected $base_paths;
+
+    public function __construct(array $base_paths)
+    {
+        $this->base_paths = $base_paths;
+    }
+
+    /**
+     * @param string $path
+     * @return string|null The absolute path if resolved; null otherwise;
+     *
+     * @throws 
+     */
+    public function resolve(string $path)
+    {
+        foreach ($this->base_paths as $base_path) {
+            $base_path = rtrim($base_path, '/');
+            $absolute_path = "{$base_path}/{$path}";
+            if ($this->_path_exists($absolute_path)) {
+                return $absolute_path;
+            }
+        }
+
+
+        return null;
+    }
+
+    /**
+     * Determines whether a file or folder exists at the specified path.
+     *
+     * @param string $path The path to the file or folder.
+     * @return bool True if the path exists; false otherwise.
+     *
+     * @throws Throwable If problem determining whether path exists.
+     */
+    protected function _path_exists(string $path)
+    {
+        return file_exists($path);
+    }
+}

--- a/classes/class-file-path-resolver.php
+++ b/classes/class-file-path-resolver.php
@@ -14,43 +14,39 @@ use Throwable;
  */
 class File_Path_Resolver {
 
-    protected $base_paths;
+	protected $base_paths;
 
-    public function __construct(array $base_paths)
-    {
-        $this->base_paths = $base_paths;
-    }
+	public function __construct( array $base_paths) {
+		$this->base_paths = $base_paths;
+	}
 
-    /**
-     * @param string $path
-     * @return string|null The absolute path if resolved; null otherwise;
-     *
-     * @throws 
-     */
-    public function resolve(string $path)
-    {
-        foreach ($this->base_paths as $base_path) {
-            $base_path = rtrim($base_path, '/');
-            $absolute_path = "{$base_path}/{$path}";
-            if ($this->_path_exists($absolute_path)) {
-                return $absolute_path;
-            }
-        }
+	/**
+	 * @param string $path
+	 * @return string|null The absolute path if resolved; null otherwise;
+	 *
+	 * @throws
+	 */
+	public function resolve( string $path) {
+		foreach ($this->base_paths as $base_path) {
+			$base_path     = rtrim( $base_path, '/' );
+			$absolute_path = "{$base_path}/{$path}";
+			if ($this->_path_exists( $absolute_path )) {
+				return $absolute_path;
+			}
+		}
 
+		return null;
+	}
 
-        return null;
-    }
-
-    /**
-     * Determines whether a file or folder exists at the specified path.
-     *
-     * @param string $path The path to the file or folder.
-     * @return bool True if the path exists; false otherwise.
-     *
-     * @throws Throwable If problem determining whether path exists.
-     */
-    protected function _path_exists(string $path)
-    {
-        return file_exists($path);
-    }
+	/**
+	 * Determines whether a file or folder exists at the specified path.
+	 *
+	 * @param string $path The path to the file or folder.
+	 * @return bool True if the path exists; false otherwise.
+	 *
+	 * @throws Throwable If problem determining whether path exists.
+	 */
+	protected function _path_exists( string $path) {
+		return file_exists( $path );
+	}
 }

--- a/classes/class-get-template-capable-trait.php
+++ b/classes/class-get-template-capable-trait.php
@@ -29,9 +29,7 @@ trait Get_Template_Capable_Trait {
 	 * @return PHP_Template The template for the key.
 	 */
 	protected function get_template( $template ) {
-		$path = $this->get_config( 'template_path_factory' )( "$template.php" );
-
-		return $this->get_config( 'template_factory' )( $path );
+		return $this->get_config( 'local_template_factory' )( $template );
 	}
 
 	/**

--- a/classes/class-quiz-shortcode-handler.php
+++ b/classes/class-quiz-shortcode-handler.php
@@ -45,13 +45,13 @@ class Quiz_Shortcode_Handler extends Handler {
 	use Index_List_Capable_Trait;
 
 	/**
-	 * The object responsible for the creation of the submission document.
+	 * The factory that, given a template, produces {@see Submission_Document_Creator} instance.
 	 *
 	 * @since [*next-version*]
 	 *
-	 * @var Submission_Document_Creator
+	 * @var callable
 	 */
-	protected $documentCreator;
+	protected $document_creator_factory;
 
 	/**
 	 * The field name of a Question that contains the max answers value for that question.
@@ -80,13 +80,13 @@ class Quiz_Shortcode_Handler extends Handler {
 	 */
 	public function __construct(
 		DI_Container $config,
-		Submission_Document_Creator $documentCreator,
+		callable $document_creator_factory,
 		string $submission_request_var_name,
 		string $question_max_answers_field_name
 	) {
 		parent::__construct( $config );
 
-		$this->documentCreator                 = $documentCreator;
+		$this->document_creator_factory        = $document_creator_factory;
 		$this->question_max_answers_field_name = $question_max_answers_field_name;
 		$this->submission_request_var_name     = $submission_request_var_name;
 	}
@@ -134,7 +134,7 @@ class Quiz_Shortcode_Handler extends Handler {
 	/**
 	 * Retrieves either the quiz or the result HTML.
 	 *
-	 * @param $attributes
+	 * @param array $attributes The map of attribute keys to values.
 	 * @param string     $content
 	 * @throws Throwable
 	 *
@@ -145,14 +145,18 @@ class Quiz_Shortcode_Handler extends Handler {
 		try {
 			// Displaying submission result
 			$var_name = $this->submission_request_var_name;
+			$attributes = wp_parse_args($attributes, [
+			    'quiz_template'           => $this->get_config('quiz_default_template_name'),
+			    'result_template'         => $this->get_config('submission_document_default_template_name')
+            ]);
 			if ( isset( $_GET[ $var_name ] ) ) {
-				return $this->render_document_for_submission( $_GET[ $var_name ] );
+				return $this->render_document_for_submission( $_GET[ $var_name ], $attributes['result_template'] );
 			}
 
 			// Displaying quiz
 			$this->validate_attributes( $attributes );
 
-			return $this->get_quiz_output( intval( $attributes['id'] ) );
+			return $this->get_quiz_output( intval( $attributes['id'] ), (string) $attributes['quiz_template'] );
 		} catch ( Throwable $e ) {
 			$message = __( 'Could not render SQuiz shortcode', 'squiz' );
 			if ( WP_DEBUG ) {
@@ -182,12 +186,13 @@ class Quiz_Shortcode_Handler extends Handler {
 	 * Retrieves the HTML output for a quiz.
 	 *
 	 * @param int $id The ID of the Quiz post to get the output for.
+     * @param string $template_name Name of the template for the output.
 	 *
 	 * @return string The HTML of the quiz.
 	 *
 	 * @throws Throwable If problem retrieving.
 	 */
-	protected function get_quiz_output( int $id ) {
+	protected function get_quiz_output( int $id, string $template_name ) {
 		$quiz              = $this->get_quiz( $id );
 		$questions         = $this->get_quiz_questions( $quiz->ID );
 		$question_ids      = array_keys( $questions );
@@ -206,7 +211,7 @@ class Quiz_Shortcode_Handler extends Handler {
 			}
 		);
 
-		return $this->get_template( 'quiz' )->render(
+		return $this->get_template( $template_name )->render(
 			[
 				'quiz'                              => $quiz,
 				'question_groups'                   => $question_groups,
@@ -366,12 +371,13 @@ class Quiz_Shortcode_Handler extends Handler {
 	 * Retrieves the output of the submission document.
 	 *
 	 * @param string $submission_code The code (slug) of the Submission to render the document for.
+     * @param string $templateName The name of the template to render with.
 	 *
 	 * @throws Throwable If problem rendering.
 	 *
 	 * @return string The output of the submission document.
 	 */
-	protected function render_document_for_submission( string $submission_code ): string {
+	protected function render_document_for_submission( string $submission_code, string $templateName ): string {
 		$submissions = $this->get_posts(
 			[
 				'post_type'   => $this->get_config( 'quiz_submission_post_type' ),
@@ -386,6 +392,11 @@ class Quiz_Shortcode_Handler extends Handler {
 			throw new OutOfRangeException( sprintf( __( 'Submission with code "%1$s" not found' ), $submission_code ) );
 		}
 
-		return $this->documentCreator->get_document_output( intval( $submission->ID ) );
+		$template = $this->get_template($templateName);
+		$factory = $this->document_creator_factory;
+		$creator = $factory($template);
+		assert($creator instanceof Submission_Document_Creator);
+
+		return $creator->get_document_output( intval( $submission->ID ) );
 	}
 }

--- a/classes/class-quiz-shortcode-handler.php
+++ b/classes/class-quiz-shortcode-handler.php
@@ -134,8 +134,8 @@ class Quiz_Shortcode_Handler extends Handler {
 	/**
 	 * Retrieves either the quiz or the result HTML.
 	 *
-	 * @param array $attributes The map of attribute keys to values.
-	 * @param string     $content
+	 * @param array  $attributes The map of attribute keys to values.
+	 * @param string $content
 	 * @throws Throwable
 	 *
 	 * @return string If the submission field is present in the URL query, retrieves the result HTML for that submission.
@@ -144,11 +144,14 @@ class Quiz_Shortcode_Handler extends Handler {
 	protected function get_shortcode_output( $attributes, $content = '' ) {
 		try {
 			// Displaying submission result
-			$var_name = $this->submission_request_var_name;
-			$attributes = wp_parse_args($attributes, [
-			    'quiz_template'           => $this->get_config('quiz_default_template_name'),
-			    'result_template'         => $this->get_config('submission_document_default_template_name')
-            ]);
+			$var_name   = $this->submission_request_var_name;
+			$attributes = wp_parse_args(
+				$attributes,
+				[
+					'quiz_template'   => $this->get_config( 'quiz_default_template_name' ),
+					'result_template' => $this->get_config( 'submission_document_default_template_name' ),
+				]
+			);
 			if ( isset( $_GET[ $var_name ] ) ) {
 				return $this->render_document_for_submission( $_GET[ $var_name ], $attributes['result_template'] );
 			}
@@ -185,8 +188,8 @@ class Quiz_Shortcode_Handler extends Handler {
 	/**
 	 * Retrieves the HTML output for a quiz.
 	 *
-	 * @param int $id The ID of the Quiz post to get the output for.
-     * @param string $template_name Name of the template for the output.
+	 * @param int    $id The ID of the Quiz post to get the output for.
+	 * @param string $template_name Name of the template for the output.
 	 *
 	 * @return string The HTML of the quiz.
 	 *
@@ -371,7 +374,7 @@ class Quiz_Shortcode_Handler extends Handler {
 	 * Retrieves the output of the submission document.
 	 *
 	 * @param string $submission_code The code (slug) of the Submission to render the document for.
-     * @param string $templateName The name of the template to render with.
+	 * @param string $templateName The name of the template to render with.
 	 *
 	 * @throws Throwable If problem rendering.
 	 *
@@ -392,10 +395,10 @@ class Quiz_Shortcode_Handler extends Handler {
 			throw new OutOfRangeException( sprintf( __( 'Submission with code "%1$s" not found' ), $submission_code ) );
 		}
 
-		$template = $this->get_template($templateName);
-		$factory = $this->document_creator_factory;
-		$creator = $factory($template);
-		assert($creator instanceof Submission_Document_Creator);
+		$template = $this->get_template( $templateName );
+		$factory  = $this->document_creator_factory;
+		$creator  = $factory( $template );
+		assert( $creator instanceof Submission_Document_Creator );
 
 		return $creator->get_document_output( intval( $submission->ID ) );
 	}

--- a/plugin.php
+++ b/plugin.php
@@ -40,9 +40,11 @@ function plugin() {
 		$services_factory = require_once "$base_dir/services.php";
 		$parent_template_path  = get_template_directory();
 		$child_template_path = get_stylesheet_directory();
+		$module_name = 'squiz'; // Code of the plugin
 		$services         = $services_factory(
 		    $base_path,
             $base_url,
+            $module_name,
             $parent_template_path,
             $child_template_path
         );

--- a/plugin.php
+++ b/plugin.php
@@ -38,7 +38,14 @@ function plugin() {
 		$base_dir         = dirname( $base_path );
 		$base_url         = plugins_url( '', $base_path );
 		$services_factory = require_once "$base_dir/services.php";
-		$services         = $services_factory( $base_path, $base_url );
+		$parent_template_path  = get_template_directory();
+		$child_template_path = get_stylesheet_directory();
+		$services         = $services_factory(
+		    $base_path,
+            $base_url,
+            $parent_template_path,
+            $child_template_path
+        );
 		$container        = new DI_Container( $services );
 
 		$instance = new Plugin( $container );

--- a/plugin.php
+++ b/plugin.php
@@ -34,21 +34,21 @@ function plugin() {
 	}
 
 	if ( is_null( $instance ) ) {
-		$base_path        = __FILE__;
-		$base_dir         = dirname( $base_path );
-		$base_url         = plugins_url( '', $base_path );
-		$services_factory = require_once "$base_dir/services.php";
-		$parent_template_path  = get_template_directory();
-		$child_template_path = get_stylesheet_directory();
-		$module_name = 'squiz'; // Code of the plugin
-		$services         = $services_factory(
-		    $base_path,
-            $base_url,
-            $module_name,
-            $parent_template_path,
-            $child_template_path
-        );
-		$container        = new DI_Container( $services );
+		$base_path            = __FILE__;
+		$base_dir             = dirname( $base_path );
+		$base_url             = plugins_url( '', $base_path );
+		$services_factory     = require_once "$base_dir/services.php";
+		$parent_template_path = get_template_directory();
+		$child_template_path  = get_stylesheet_directory();
+		$module_name          = 'squiz'; // Code of the plugin
+		$services             = $services_factory(
+			$base_path,
+			$base_url,
+			$module_name,
+			$parent_template_path,
+			$child_template_path
+		);
+		$container            = new DI_Container( $services );
 
 		$instance = new Plugin( $container );
 	}

--- a/services.php
+++ b/services.php
@@ -26,8 +26,15 @@ use XedinUnknown\SQuiz\Template_Block;
  *
  * @return array A map of service names to service definitions.
  */
-return function ( $base_path, $base_url, $parent_theme_path, $child_theme_path ) {
+return function (
+    $base_path,
+    $base_url,
+    $module_name,
+    $parent_theme_path,
+    $child_theme_path
+) {
 		return [
+		    'name'                                   => $module_name,
 			'version'                                => '[*next-version*]',
 			'base_path'                              => $base_path,
 			'base_dir'                               => dirname( $base_path ),
@@ -37,7 +44,9 @@ return function ( $base_path, $base_url, $parent_theme_path, $child_theme_path )
             'parent_theme_path'                      => $parent_theme_path,
             'child_theme_path'                       => $child_theme_path,
 			'translations_dir'                       => '/languages',
-			'text_domain'                            => 'squiz',
+			'text_domain'                            => function ( DI_Container $c ) {
+		        return $c->get('name');
+            },
 
             'translation'                            => function ( DI_Container $c ) {
 		        $text_domain = $c->get('text_domain');

--- a/services.php
+++ b/services.php
@@ -25,7 +25,7 @@ use XedinUnknown\SQuiz\Template_Block;
  *
  * @return array A map of service names to service definitions.
  */
-return function ( $base_path, $base_url ) {
+return function ( $base_path, $base_url, $parent_theme_path, $child_theme_path ) {
 		return [
 			'version'                                => '[*next-version*]',
 			'base_path'                              => $base_path,
@@ -33,6 +33,8 @@ return function ( $base_path, $base_url ) {
 			'base_url'                               => $base_url,
 			'js_path'                                => '/assets/js',
 			'templates_dir'                          => '/templates',
+            'parent_theme_path'                      => $parent_theme_path,
+            'child_theme_path'                       => $child_theme_path,
 			'translations_dir'                       => '/languages',
 			'text_domain'                            => 'squiz',
 

--- a/services.php
+++ b/services.php
@@ -8,6 +8,7 @@
 use XedinUnknown\SQuiz\Callback_Block;
 use XedinUnknown\SQuiz\DI_Container;
 use XedinUnknown\SQuiz\Fields_Types_Handler;
+use XedinUnknown\SQuiz\File_Path_Resolver;
 use XedinUnknown\SQuiz\PHP_Template;
 use XedinUnknown\SQuiz\Quiz_Shortcode_Handler;
 use XedinUnknown\SQuiz\Quiz_Submission_Handler;
@@ -398,5 +399,25 @@ return function ( $base_path, $base_url, $parent_theme_path, $child_theme_path )
 
 				return new PHP_Template( $templatePath );
 			},
+
+            'template_path_resolver' => function ( DI_Container $c ) {
+			    return new File_Path_Resolver($c->get('template_directories'));
+            },
+
+            'template_directories' => function ( DI_Container $c ) {
+			    $parent_theme_path = $c->get('parent_theme_path');
+			    $child_theme_path = $c->get('child_theme_path');
+			    $template_path_factory = $c->get('template_path_factory');
+			    $local_template_path = $template_path_factory('');
+			    $dirs = [$child_theme_path];
+
+			    if ($parent_theme_path !== $child_theme_path) {
+			        $dirs[] = $parent_theme_path;
+                }
+
+			    $dirs[] = $local_template_path;
+
+			    return $dirs;
+            },
 		];
 };

--- a/services.php
+++ b/services.php
@@ -43,6 +43,7 @@ return function (
 			'templates_dir'                          => '/templates',
             'parent_theme_path'                      => $parent_theme_path,
             'child_theme_path'                       => $child_theme_path,
+            'theme_template_dir'                     => '__modules',
 			'translations_dir'                       => '/languages',
 			'text_domain'                            => function ( DI_Container $c ) {
 		        return $c->get('name');
@@ -443,14 +444,16 @@ return function (
             },
 
             'template_directories' => function ( DI_Container $c ) {
-			    $parent_theme_path = $c->get('parent_theme_path');
-			    $child_theme_path = $c->get('child_theme_path');
+			    $theme_template_dir = trim($c->get('theme_template_dir'), '/');
+			    $child_dir_name = basename($c->get('name'));
+			    $parent_theme_path = rtrim($c->get('parent_theme_path'), '/');
+			    $child_theme_path = rtrim($c->get('child_theme_path'), '/');
 			    $template_path_factory = $c->get('template_path_factory');
 			    $local_template_path = $template_path_factory('');
-			    $dirs = [$child_theme_path];
+			    $dirs = ["{$child_theme_path}/{$theme_template_dir}/{$child_dir_name}"];
 
 			    if ($parent_theme_path !== $child_theme_path) {
-			        $dirs[] = $parent_theme_path;
+			        $dirs[] = "{$parent_theme_path}/{$theme_template_dir}/{$child_dir_name}";
                 }
 
 			    $dirs[] = $local_template_path;

--- a/services.php
+++ b/services.php
@@ -39,6 +39,14 @@ return function ( $base_path, $base_url, $parent_theme_path, $child_theme_path )
 			'translations_dir'                       => '/languages',
 			'text_domain'                            => 'squiz',
 
+            'translation'                            => function ( DI_Container $c ) {
+		        $text_domain = $c->get('text_domain');
+
+		        return function (string $string, $placeholders = []) use ($text_domain): string {
+                    return vsprintf(__($string, $text_domain), $placeholders);
+                };
+            },
+
 			'template_path_factory'                  => function ( DI_Container $c ) {
 				$baseDir      = rtrim( $c->get( 'base_dir' ), '\\/' );
 				$templatesDir = trim( $c->get( 'templates_dir' ), '\\/' );

--- a/services.php
+++ b/services.php
@@ -27,37 +27,37 @@ use XedinUnknown\SQuiz\Template_Block;
  * @return array A map of service names to service definitions.
  */
 return function (
-    $base_path,
-    $base_url,
-    $module_name,
-    $parent_theme_path,
-    $child_theme_path
+	$base_path,
+	$base_url,
+	$module_name,
+	$parent_theme_path,
+	$child_theme_path
 ) {
 		return [
-		    'name'                                   => $module_name,
-			'version'                                => '[*next-version*]',
-			'base_path'                              => $base_path,
-			'base_dir'                               => dirname( $base_path ),
-			'base_url'                               => $base_url,
-			'js_path'                                => '/assets/js',
-			'templates_dir'                          => '/templates',
-            'parent_theme_path'                      => $parent_theme_path,
-            'child_theme_path'                       => $child_theme_path,
-            'theme_template_dir'                     => '__modules',
-			'translations_dir'                       => '/languages',
-			'text_domain'                            => function ( DI_Container $c ) {
-		        return $c->get('name');
-            },
+			'name'                                      => $module_name,
+			'version'                                   => '[*next-version*]',
+			'base_path'                                 => $base_path,
+			'base_dir'                                  => dirname( $base_path ),
+			'base_url'                                  => $base_url,
+			'js_path'                                   => '/assets/js',
+			'templates_dir'                             => '/templates',
+			'parent_theme_path'                         => $parent_theme_path,
+			'child_theme_path'                          => $child_theme_path,
+			'theme_template_dir'                        => '__modules',
+			'translations_dir'                          => '/languages',
+			'text_domain'                               => function ( DI_Container $c ) {
+				return $c->get( 'name' );
+			},
 
-            'translation'                            => function ( DI_Container $c ) {
-		        $text_domain = $c->get('text_domain');
+			'translation'                               => function ( DI_Container $c ) {
+				$text_domain = $c->get( 'text_domain' );
 
-		        return function (string $string, $placeholders = []) use ($text_domain): string {
-                    return vsprintf(__($string, $text_domain), $placeholders);
-                };
-            },
+				return function ( string $string, $placeholders = []) use ( $text_domain): string {
+					return vsprintf( __( $string, $text_domain ), $placeholders );
+				};
+			},
 
-			'template_path_factory'                  => function ( DI_Container $c ) {
+			'template_path_factory'                     => function ( DI_Container $c ) {
 				$baseDir      = rtrim( $c->get( 'base_dir' ), '\\/' );
 				$templatesDir = trim( $c->get( 'templates_dir' ), '\\/' );
 
@@ -73,39 +73,39 @@ return function (
 			 *
 			 * @since 0.1
 			 */
-			'template_factory'                       => function ( DI_Container $c ) {
+			'template_factory'                          => function ( DI_Container $c ) {
 				return function ( $path ) {
 					return new PHP_Template( $path );
 				};
 			},
 
-            'local_template_factory' => function ( DI_Container $c ) {
-			    $resolver = $c->get('template_path_resolver');
-			    assert($resolver instanceof File_Path_Resolver);
+			'local_template_factory'                    => function ( DI_Container $c ) {
+				$resolver = $c->get( 'template_path_resolver' );
+				assert( $resolver instanceof File_Path_Resolver );
 
-			    $t = $c->get('translation');
-			    assert(is_callable($t));
+				$t = $c->get( 'translation' );
+				assert( is_callable( $t ) );
 
-			    $f = $c->get('template_factory');
-			    assert($f instanceof PHP_Template);
+				$f = $c->get( 'template_factory' );
+				assert( $f instanceof PHP_Template );
 
-			    return function ($template) use ($resolver, $f, $t) {
-			        $template = "{$template}.php";
-                    $path = $resolver->resolve($template);
-                    if ($path === null) {
-                        throw new UnexpectedValueException($t('The path for template "%1$s" could not be resolved', [$template]));
-                    }
+				return function ( $template) use ( $resolver, $f, $t) {
+					$template = "{$template}.php";
+					$path     = $resolver->resolve( $template );
+					if ($path === null) {
+						throw new UnexpectedValueException( $t( 'The path for template "%1$s" could not be resolved', [ $template ] ) );
+					}
 
-                    return $f($path);
-                };
-            },
+					return $f( $path );
+				};
+			},
 
 			/*
 			 * Makes blocs.
 			 *
 			 * @since 0.1
 			 */
-			'block_factory'                          => function ( DI_Container $c ) {
+			'block_factory'                             => function ( DI_Container $c ) {
 				return function ( PHP_Template $template, $context ) {
 					return new Template_Block( $template, $context );
 				};
@@ -116,7 +116,7 @@ return function (
 			 *
 			 * @since 0.1
 			 */
-			'callback_block_factory'                 => function ( DI_Container $c ) {
+			'callback_block_factory'                    => function ( DI_Container $c ) {
 				return function ( callable $callback, $context = [] ) {
 					return new Callback_Block( $callback, $context );
 				};
@@ -127,7 +127,7 @@ return function (
 			 *
 			 * @since 0.1
 			 */
-			'handlers'                               => function ( DI_Container $c ) {
+			'handlers'                                  => function ( DI_Container $c ) {
 				return [
 					$c->get( 'fields_types_handler' ),
 					$c->get( 'quiz_shortcode_handler' ),
@@ -135,36 +135,36 @@ return function (
 				];
 			},
 
-			'question_groups_taxonomy'               => function ( DI_Container $c ) {
+			'question_groups_taxonomy'                  => function ( DI_Container $c ) {
 				return 'question_groups';
 			},
 
-			'answer_post_type'                       => function ( DI_Container $c ) {
+			'answer_post_type'                          => function ( DI_Container $c ) {
 				return 'answer';
 			},
 
-			'question_post_type'                     => function ( DI_Container $c ) {
+			'question_post_type'                        => function ( DI_Container $c ) {
 				return 'question';
 			},
 
-			'questions_to_answers_relationship_name' => 'questions_to_answers',
+			'questions_to_answers_relationship_name'    => 'questions_to_answers',
 
-			'course_post_type'                       => function ( DI_Container $c ) {
+			'course_post_type'                          => function ( DI_Container $c ) {
 				return 'courses';
 			},
 
-			'course_groups_taxonomy'                 => function ( DI_Container $c ) {
+			'course_groups_taxonomy'                    => function ( DI_Container $c ) {
 				return 'course_groups';
 			},
 
-			'quiz_post_type'                         => 'quiz',
-			'quiz_submission_post_type'              => 'quiz_submission',
+			'quiz_post_type'                            => 'quiz',
+			'quiz_submission_post_type'                 => 'quiz_submission',
 
-			'quizes_to_questions_relationship_name'  => 'quizes_to_questions',
+			'quizes_to_questions_relationship_name'     => 'quizes_to_questions',
 
-			'answers_to_courses_relationship_name'   => 'answers_to_courses',
+			'answers_to_courses_relationship_name'      => 'answers_to_courses',
 
-			'field_relationships'                    => function ( DI_Container $c ) {
+			'field_relationships'                       => function ( DI_Container $c ) {
 				return [
 					$c->get( 'questions_to_answers_relationship_name' ) => [
 						'from' => [
@@ -222,11 +222,11 @@ return function (
 				];
 			},
 
-			'fields_types_handler'                   => function ( DI_Container $c ) {
+			'fields_types_handler'                      => function ( DI_Container $c ) {
 				return new Fields_Types_Handler( $c );
 			},
 
-			'quiz_shortcode_handler'                 => function ( DI_Container $c ) {
+			'quiz_shortcode_handler'                    => function ( DI_Container $c ) {
 				return new Quiz_Shortcode_Handler(
 					$c,
 					$c->get( 'quiz_submission_document_creator_factory' ),
@@ -238,7 +238,7 @@ return function (
 			/*
 			 * @see https://codex.wordpress.org/Function_Reference/register_post_type
 			 */
-			'post_types'                             => function ( DI_Container $c ) {
+			'post_types'                                => function ( DI_Container $c ) {
 				return [
 					$c->get( 'question_post_type' )        => [
 						'labels'              => [
@@ -334,7 +334,7 @@ return function (
 				];
 			},
 
-			'taxonomies'                             => function ( DI_Container $c ) {
+			'taxonomies'                                => function ( DI_Container $c ) {
 				return [
 					$c->get( 'question_groups_taxonomy' ) => [
 						'object_type'  => [ $c->get( 'question_post_type' ) ],
@@ -365,10 +365,10 @@ return function (
 					],
 				];
 			},
-			'course_groups_max_courses_field'        => 'max_courses',
-			'course_groups_description_field'        => 'long_description',
-			'question_max_answers_field'             => 'max_answers',
-			'taxonomy_metaboxes'                     => function ( DI_Container $c ) {
+			'course_groups_max_courses_field'           => 'max_courses',
+			'course_groups_description_field'           => 'long_description',
+			'question_max_answers_field'                => 'max_answers',
+			'taxonomy_metaboxes'                        => function ( DI_Container $c ) {
 				return [
 					[
 						'title'      => __( 'Quiz Submissions' ),
@@ -405,56 +405,56 @@ return function (
 					],
 				];
 			},
-			'quiz_shortcode_name'                    => 'squiz',
-			'submission_request_var_name'            => 'submission',
-			'submission_answer_groups_var_name'      => 'squiz-answers',
-			'submission_field_quiz_id'               => 'squiz_quiz_id',
-			'submission_field_grouped_answers'       => 'squiz_grouped_answers',
+			'quiz_shortcode_name'                       => 'squiz',
+			'submission_request_var_name'               => 'submission',
+			'submission_answer_groups_var_name'         => 'squiz-answers',
+			'submission_field_quiz_id'                  => 'squiz_quiz_id',
+			'submission_field_grouped_answers'          => 'squiz_grouped_answers',
 			'submission_document_default_template_name' => 'quiz-result',
-            'quiz_default_template_name'             => 'quiz',
+			'quiz_default_template_name'                => 'quiz',
 
-			'quiz_submission_handler'                => function ( DI_Container $c ) {
+			'quiz_submission_handler'                   => function ( DI_Container $c ) {
 				return new Quiz_Submission_Handler(
 					$c,
 					$c->get( 'submission_request_var_name' )
 				);
 			},
 
-            'quiz_submission_document_creator_factory' => function ( DI_Container $c) {
-			    return function (PHP_Template $template) use ($c) {
-                    return new Submission_Document_Creator(
-                        $c->get( 'submission_field_grouped_answers' ),
-                        $c->get( 'submission_field_quiz_id' ),
-                        $c->get( 'quiz_post_type' ),
-                        $c->get( 'quiz_submission_post_type' ),
-                        $c->get( 'course_groups_taxonomy' ),
-                        $c->get( 'answers_to_courses_relationship_name' ),
-                        $c->get( 'course_groups_max_courses_field' ),
-                        $template
-                    );
-                };
-            },
+			'quiz_submission_document_creator_factory'  => function ( DI_Container $c) {
+				return function ( PHP_Template $template) use ( $c) {
+					return new Submission_Document_Creator(
+						$c->get( 'submission_field_grouped_answers' ),
+						$c->get( 'submission_field_quiz_id' ),
+						$c->get( 'quiz_post_type' ),
+						$c->get( 'quiz_submission_post_type' ),
+						$c->get( 'course_groups_taxonomy' ),
+						$c->get( 'answers_to_courses_relationship_name' ),
+						$c->get( 'course_groups_max_courses_field' ),
+						$template
+					);
+				};
+			},
 
-            'template_path_resolver' => function ( DI_Container $c ) {
-			    return new File_Path_Resolver($c->get('template_directories'));
-            },
+			'template_path_resolver'                    => function ( DI_Container $c ) {
+				return new File_Path_Resolver( $c->get( 'template_directories' ) );
+			},
 
-            'template_directories' => function ( DI_Container $c ) {
-			    $theme_template_dir = trim($c->get('theme_template_dir'), '/');
-			    $child_dir_name = basename($c->get('name'));
-			    $parent_theme_path = rtrim($c->get('parent_theme_path'), '/');
-			    $child_theme_path = rtrim($c->get('child_theme_path'), '/');
-			    $template_path_factory = $c->get('template_path_factory');
-			    $local_template_path = $template_path_factory('');
-			    $dirs = ["{$child_theme_path}/{$theme_template_dir}/{$child_dir_name}"];
+			'template_directories'                      => function ( DI_Container $c ) {
+				$theme_template_dir    = trim( $c->get( 'theme_template_dir' ), '/' );
+				$child_dir_name        = basename( $c->get( 'name' ) );
+				$parent_theme_path     = rtrim( $c->get( 'parent_theme_path' ), '/' );
+				$child_theme_path      = rtrim( $c->get( 'child_theme_path' ), '/' );
+				$template_path_factory = $c->get( 'template_path_factory' );
+				$local_template_path   = $template_path_factory( '' );
+				$dirs                  = [ "{$child_theme_path}/{$theme_template_dir}/{$child_dir_name}" ];
 
-			    if ($parent_theme_path !== $child_theme_path) {
-			        $dirs[] = "{$parent_theme_path}/{$theme_template_dir}/{$child_dir_name}";
-                }
+				if ($parent_theme_path !== $child_theme_path) {
+					$dirs[] = "{$parent_theme_path}/{$theme_template_dir}/{$child_dir_name}";
+				}
 
-			    $dirs[] = $local_template_path;
+				$dirs[] = $local_template_path;
 
-			    return $dirs;
-            },
+				return $dirs;
+			},
 		];
 };

--- a/services.php
+++ b/services.php
@@ -229,7 +229,7 @@ return function (
 			'quiz_shortcode_handler'                 => function ( DI_Container $c ) {
 				return new Quiz_Shortcode_Handler(
 					$c,
-					$c->get( 'quiz_submission_document_creator' ),
+					$c->get( 'quiz_submission_document_creator_factory' ),
 					$c->get( 'submission_request_var_name' ),
 					$c->get( 'question_max_answers_field' )
 				);
@@ -410,7 +410,8 @@ return function (
 			'submission_answer_groups_var_name'      => 'squiz-answers',
 			'submission_field_quiz_id'               => 'squiz_quiz_id',
 			'submission_field_grouped_answers'       => 'squiz_grouped_answers',
-			'submission_document_template_name'      => 'quiz-result',
+			'submission_document_default_template_name' => 'quiz-result',
+            'quiz_default_template_name'             => 'quiz',
 
 			'quiz_submission_handler'                => function ( DI_Container $c ) {
 				return new Quiz_Submission_Handler(
@@ -419,25 +420,20 @@ return function (
 				);
 			},
 
-			'quiz_submission_document_creator'       => function ( DI_Container $c ) {
-				return new Submission_Document_Creator(
-					$c->get( 'submission_field_grouped_answers' ),
-					$c->get( 'submission_field_quiz_id' ),
-					$c->get( 'quiz_post_type' ),
-					$c->get( 'quiz_submission_post_type' ),
-					$c->get( 'course_groups_taxonomy' ),
-					$c->get( 'answers_to_courses_relationship_name' ),
-					$c->get( 'course_groups_max_courses_field' ),
-					$c->get( 'quiz_submission_document_template' )
-				);
-			},
-
-			'quiz_submission_document_template'      => function ( DI_Container $c ) {
-				$templateName = $c->get( 'submission_document_template_name' );
-				$templatePath = $c->get( 'template_path_factory' )( "$templateName.php" );
-
-				return new PHP_Template( $templatePath );
-			},
+            'quiz_submission_document_creator_factory' => function ( DI_Container $c) {
+			    return function (PHP_Template $template) use ($c) {
+                    return new Submission_Document_Creator(
+                        $c->get( 'submission_field_grouped_answers' ),
+                        $c->get( 'submission_field_quiz_id' ),
+                        $c->get( 'quiz_post_type' ),
+                        $c->get( 'quiz_submission_post_type' ),
+                        $c->get( 'course_groups_taxonomy' ),
+                        $c->get( 'answers_to_courses_relationship_name' ),
+                        $c->get( 'course_groups_max_courses_field' ),
+                        $template
+                    );
+                };
+            },
 
             'template_path_resolver' => function ( DI_Container $c ) {
 			    return new File_Path_Resolver($c->get('template_directories'));

--- a/services.php
+++ b/services.php
@@ -69,6 +69,27 @@ return function ( $base_path, $base_url, $parent_theme_path, $child_theme_path )
 				};
 			},
 
+            'local_template_factory' => function ( DI_Container $c ) {
+			    $resolver = $c->get('template_path_resolver');
+			    assert($resolver instanceof File_Path_Resolver);
+
+			    $t = $c->get('translation');
+			    assert(is_callable($t));
+
+			    $f = $c->get('template_factory');
+			    assert($f instanceof PHP_Template);
+
+			    return function ($template) use ($resolver, $f, $t) {
+			        $template = "{$template}.php";
+                    $path = $resolver->resolve($template);
+                    if ($path === null) {
+                        throw new UnexpectedValueException($t('The path for template "%1$s" could not be resolved', [$template]));
+                    }
+
+                    return $f($path);
+                };
+            },
+
 			/*
 			 * Makes blocs.
 			 *


### PR DESCRIPTION
The shortcode receives 2 new _optional_ attributes, `quiz_template` and `result_template`. They allow specifying the template _names_ for the quiz template and quiz submission template, respectively. They default to the same values as before, `quiz` and `quiz-result` respectively. The plugin will look for the file with that name plus ".php" suffix in the following locations, in that order:

1. The child theme's `__modules/squiz` directory.
2. The parent theme's `__modules/squiz` directory.
3. The plugin's `templates` directory.

Effectively, the templates that had to be included in the plugin under `templates` can now be overridden from the child or the parent theme.

This fixes #4.